### PR TITLE
fix: add DependsOn to QBusinessPlugin

### DIFF
--- a/deployment/Q-App.yaml
+++ b/deployment/Q-App.yaml
@@ -98,6 +98,7 @@ Resources:
                     arn:aws:qbusiness:${AWS::Region}:${AWS::AccountId}:application/${QBusinessApplication}/index/*/data-source/*
   QBusinessPlugin:
     Type: 'AWS::QBusiness::Plugin'
+    DependsOn: QBusinessApplication
     Properties:
       ApplicationId: !Ref QBusinessApplication
       DisplayName: HRTimeOff


### PR DESCRIPTION
## Issue

Without an explicit `DependsOn`, the `QBusinessPlugin` resource fails during stack creation with:

## Fix

Added:
```yaml
DependsOn: QBusinessApplication